### PR TITLE
closes #3 overload strategy execute

### DIFF
--- a/src/Engine.Tests/Engine.Tests.csproj
+++ b/src/Engine.Tests/Engine.Tests.csproj
@@ -21,6 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="7.2.0" />
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Engine.Tests/GlobalUsings.cs
+++ b/src/Engine.Tests/GlobalUsings.cs
@@ -1,4 +1,5 @@
 ﻿global using System.Diagnostics.CodeAnalysis;
+global using FakeItEasy;
 global using FluentAssertions;
 global using FluentAssertions.Execution;
 global using Xunit;

--- a/src/Engine.Tests/StrategyInterfaceTests.cs
+++ b/src/Engine.Tests/StrategyInterfaceTests.cs
@@ -1,0 +1,30 @@
+﻿namespace Dgt.Nonograms.Engine.Tests;
+
+public class StrategyInterfaceTests
+{
+    // FakeItEasy does not pick up default interface implementations. We can define a type that does pick those methods up,
+    // but can still be faked. This gives us the best of both worlds in that we get the default behaviour, but can still
+    // assert against the other methods
+    public abstract class TestableStrategy : IStrategy
+    {
+        public abstract Line Execute(Hint hint, Line line);
+    }
+
+    [Theory]
+    [InlineData("1", "000")]
+    [InlineData("2,2", ".....")]
+    [InlineData("3,1", "000...0.1")]
+    public void ExecuteWithStrings_Should_ExecuteWithParsedHintAndLine(string hint, string line)
+    {
+        // Arrange
+        IStrategy fakeStrategy = A.Fake<TestableStrategy>();
+        var expectedHint = Hint.Parse(hint);
+        var expectedLine = Line.Parse(line);
+
+        // Act
+        _ = fakeStrategy.Execute(hint, line);
+
+        // Assert
+        A.CallTo(() => fakeStrategy.Execute(expectedHint, expectedLine)).MustHaveHappenedOnceExactly();
+    }
+}

--- a/src/Engine.Tests/StrategyInterfaceTests.cs
+++ b/src/Engine.Tests/StrategyInterfaceTests.cs
@@ -10,6 +10,43 @@ public class StrategyInterfaceTests
         public abstract Line Execute(Hint hint, Line line);
     }
 
+    [Fact]
+    public void ExecuteWithStrings_Should_ThrowWhenHintStringIsNotValid()
+    {
+        // Arrange
+        IStrategy fakeStrategy = A.Fake<TestableStrategy>();
+
+        // Act
+        var act = () => _ = fakeStrategy.Execute("I Am Not A Hint", ".....");
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Value could not be parsed into a hint.*")
+            .WithMessage("*Actual value was 'I Am Not A Hint'.*")
+            .WithParameterName("hint")
+            .Where(ex => ex.Data.Contains("hint") && ex.Data["hint"]!.Equals("I Am Not A Hint"))
+            .WithInnerException<FormatException>();
+            
+    }
+
+    [Fact]
+    public void ExecuteWithStrings_Should_ThrowWhenLineStringIsNotValid()
+    {
+        // Arrange
+        IStrategy fakeStrategy = A.Fake<TestableStrategy>();
+
+        // Act
+        var act = () => _ = fakeStrategy.Execute("2,2", "I Am Not A Line");
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Value could not be parsed into a line.*")
+            .WithMessage("*Actual value was 'I Am Not A Line'.*")
+            .WithParameterName("line")
+            .Where(ex => ex.Data.Contains("line") && ex.Data["line"]!.Equals("I Am Not A Line"))
+            .WithInnerException<FormatException>();
+    }
+
     [Theory]
     [InlineData("1", "000")]
     [InlineData("2,2", ".....")]

--- a/src/Engine/IStrategy.cs
+++ b/src/Engine/IStrategy.cs
@@ -2,6 +2,41 @@
 
 public interface IStrategy
 {
-    Line Execute(string hint, string line) => Execute(Hint.Parse(hint), Line.Parse(line));
+    Line Execute(string hint, string line)
+    {
+        Hint parsedHint;
+        Line parsedLine;
+
+        try
+        {
+            parsedHint = Hint.Parse(hint);
+        }
+        catch (FormatException fe)
+        {
+            throw CreateParsingException(nameof(hint), hint, fe);
+        }
+
+        try
+        {
+            parsedLine = Line.Parse(line);
+        }
+        catch (FormatException fe)
+        {
+            throw CreateParsingException(nameof(line), line, fe);
+        }
+
+        return Execute(parsedHint, parsedLine);
+    }
+
+    private static Exception CreateParsingException(string paramName, string paramValue, FormatException innerException)
+    {
+        var message = $"Value could not be parsed into a {paramName}. Actual value was '{paramValue}'.";
+
+        return new ArgumentException(message, paramName, innerException)
+        {
+            Data = { { paramName, paramValue } }
+        };
+    }
+    
     Line Execute(Hint hint, Line line);
 }

--- a/src/Engine/IStrategy.cs
+++ b/src/Engine/IStrategy.cs
@@ -2,5 +2,6 @@
 
 public interface IStrategy
 {
+    Line Execute(string hint, string line) => Execute(Hint.Parse(hint), Line.Parse(line));
     Line Execute(Hint hint, Line line);
 }


### PR DESCRIPTION
This adds an overload of `IStrategy.Execute` that accepts `string` parameters, rather than `Hint` and `Line` The overload has a default implementations so existing inheritors do not break. This wouldn't have been too big a deal anyway considering we only have one actual implementation, and then several types that extend the implementation.